### PR TITLE
 [REFIX] Disable distributed tracing PHP8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM php:8.1-fpm-buster
 
 ARG XDEBUG=xdebug-3.1.3
 ARG APCU=apcu-5.1.21
-ARG NEWRELIC=9.20.0.310
-ARG PHP_SECURITY_CHECKER=1.2.0
+ARG NEWRELIC=9.21.0.311
+ARG PHP_SECURITY_CHECKER=2.0.3
 
 COPY entrypoint.sh /entrypoint.sh
 COPY config/ /usr/local/etc/php/config/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,12 +21,10 @@ then
     if [[ -n $NEW_RELIC_KEY && -n $NEW_RELIC_APP_NAME ]]; then
         NEW_RELIC_IGNORE='Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException,Symfony\\Component\\HttpKernel\\Exception\\AccessDeniedHttpException,Symfony\\Component\\HttpKernel\\Exception\\MethodNotAllowedHttpException'
         sed -E -i \
-            -e 's/(newrelic.license) = "(.*)"/\1 = "'$NEW_RELIC_KEY'"/' \
-            -e "s/(newrelic.error_collector.ignore_exceptions) = \"(.*)\"/\1 = \"$NEW_RELIC_IGNORE\"/" \
-            -e 's/(newrelic.appname) = "(.*)"/\1 = "'$NEW_RELIC_APP_NAME'"/' \
-            -e 's/\;(newrelic.error_collector.ignore_exceptions)/\1/' \
-            -e 's/\;(newrelic.distributed_tracing_enabled)/\1/' \
-            -e 's/(newrelic.distributed_tracing_enabled) = (.*)/\1 = true/' \
+            -e 's/(newrelic.license) =.*/\1 = "'$NEW_RELIC_KEY'"/' \
+            -e 's/(newrelic.appname) =.*/\1 = "'$NEW_RELIC_APP_NAME'"/' \
+            -e "s/;*(newrelic.error_collector.ignore_exceptions) =.*/\1 = \"$NEW_RELIC_IGNORE\"/" \
+            -e 's/;*(newrelic.distributed_tracing_enabled) =.*/\1 = false/' \
             /usr/local/etc/php/conf.d/newrelic.ini
     fi    
 else


### PR DESCRIPTION
* Disabled the distributed tracing to avoid filling out data retention.
* Upgrade New Relic agent to 9.21.0.311 and PHP Security Checker to 2.0.3