### PR TITLE
[FEATURE]Update php, newrelic, apcu versions [skip_ci]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:8.2-fpm-bookworm
 
-ARG XDEBUG=xdebug-3.2.2
-ARG APCU=apcu-5.1.23
-ARG NEWRELIC=10.14.0.3
+ARG XDEBUG=xdebug-3.2.0
+ARG APCU=apcu-5.1.22
+ARG NEWRELIC=10.9.0.324
 ARG PHP_SECURITY_CHECKER=2.0.6
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:8.2-fpm-bookworm
 
-ARG XDEBUG=xdebug-3.2.0
-ARG APCU=apcu-5.1.22
-ARG NEWRELIC=10.9.0.324
+ARG XDEBUG=xdebug-3.2.2
+ARG APCU=apcu-5.1.23
+ARG NEWRELIC=10.14.0.3
 ARG PHP_SECURITY_CHECKER=2.0.6
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM php:8.2-fpm-buster
+FROM php:8.2-fpm-bookworm
 
 ARG XDEBUG=xdebug-3.2.2
-ARG APCU=apcu-5.1.22
-ARG NEWRELIC=10.11.0.3
+ARG APCU=apcu-5.1.23
+ARG NEWRELIC=10.14.0.3
 ARG PHP_SECURITY_CHECKER=2.0.6
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
# Referencias

- Kanbanflow: [Actualizar PHP-FPM](https://kanbanflow.com/t/tMiWY7CY)

## Lista de comprobación

- [ ] Se han creado tareas en Kanbanflow para los puntos que queden pendientes o que no se harán en esta PR.
- [x] El título de la PR sigue el [estándar de etiquetado](https://github.com/opositatest/standards/blob/master/vcs/git.md#pull-request).

## Qué se hizo

- Actualizar php a la version 8.2-fpm-bookworm que usa actualmente 8.2.12
- Actualizar apcu a 5.1.23
- Actualizar Newrelic a 10.14.0.3
