### PR TITLE
[FEATURE] Change xdebug client host

### DIFF
--- a/config/xdebug.ini
+++ b/config/xdebug.ini
@@ -1,5 +1,5 @@
 xdebug.mode = debug
 xdebug.client_port=9001
-xdebug.client_host=docker-host.localhost
+xdebug.client_host=host.docker.internal
 xdebug.log="/tmp/xdebug.log"
 xdebug.start_with_request=trigger


### PR DESCRIPTION
Change xdebug.client_host=docker-host.localhost to host.docker.internal as more standard to name host